### PR TITLE
#43 Display map of destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 
 # Visual studio code
 /.vscode
+
+# env
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 
 # idea
 .idea/*
+
+# Visual studio code
+/.vscode

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,13 @@ import "./components/fontawesome";
 import "./App.scss";
 import ModalContainer from "./components/Modal/ModalContainer";
 import { Trecipe } from "./pages/Trecipe/Trecipe";
+import { StaticMap } from "./components/Map/StaticMap";
 
 function App() {
   return (
     <div className="App">
       <Trecipe />
+      <StaticMap />
       <ModalContainer />
     </div>
   );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -44,7 +44,7 @@ export class Button extends Component<ButtonProps, ButtonState> {
 
   render() {
     return (
-      <div>
+      <div className="button-wrapper">
         <button
           className={
             this.props.text === "" && !isUndefined(this.props.icon)

--- a/src/components/Map/StaticMap.scss
+++ b/src/components/Map/StaticMap.scss
@@ -2,8 +2,8 @@
 
 .static-map-wrapper {
   display: flex;
-  // TODO: maybe remove this and let parent element decide the size
-  height: 31.25rem;
+  width: 100%;
+  height: 100%;
 }
 
 .static-map-image {

--- a/src/components/Map/StaticMap.scss
+++ b/src/components/Map/StaticMap.scss
@@ -1,0 +1,50 @@
+@import "../variables";
+
+.static-map-wrapper {
+  display: flex;
+  // TODO: maybe remove this and let parent element decide the size
+  height: 31.25rem;
+}
+
+.static-map-image {
+  width: 100%;
+  height: 100%;
+  flex: none;
+  z-index: 50;
+
+  img {
+    object-fit: contain;
+  }
+}
+
+.static-map-overlay {
+  width: 100%;
+  margin-left: -100%;
+  z-index: 100;
+  transition: background-color 0.5s;
+  cursor: pointer;
+
+  .button-wrapper {
+    height: 100%;
+    position: relative;
+
+    .button {
+      opacity: 0;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      transition: opacity 0.5s;
+    }
+  }
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.65);
+    .button {
+      opacity: 1;
+      background-color: white;
+      color: $mid-gray;
+      border-color: $mid-gray;
+    }
+  }
+}

--- a/src/components/Map/StaticMap.scss
+++ b/src/components/Map/StaticMap.scss
@@ -3,7 +3,6 @@
 .static-map-wrapper {
   display: flex;
   width: 100%;
-  height: 100%;
 }
 
 .static-map-image {

--- a/src/components/Map/StaticMap.tsx
+++ b/src/components/Map/StaticMap.tsx
@@ -129,12 +129,15 @@ export class StaticMap extends Component<StaticMapProps> {
     return (
       <div className="static-map-wrapper">
         <div className="static-map-image">
-          <Image src={this.getMapUrl(this.props)} />
+          <Image
+            src={this.getMapUrl(this.props)}
+            imgStyle={{ borderRadius: "8px" }}
+          />
         </div>
         <div
           className="static-map-overlay"
           onClick={(e) => this.props.onClick(e)}>
-          <Button icon="expand" text="Expand View" />
+          <Button icon="external-link-alt" text="Expand View" />
         </div>
       </div>
     );

--- a/src/components/Map/StaticMap.tsx
+++ b/src/components/Map/StaticMap.tsx
@@ -1,0 +1,142 @@
+import React, { MouseEvent, Component } from "react";
+import { Image } from "../Image/Image";
+import { Button } from "../Button/Button";
+import { MAP_KEY } from "./constant";
+import "./StaticMap.scss";
+
+/**
+ * MarkerColor
+ * Color (24-bit) for markers on the map
+ */
+export enum MarkerColor {
+  Blue = "58a5fc",
+  Grey = "82aabf",
+}
+
+/**
+ * Marker
+ * lat: latitude of the marker
+ * long: longitude of the marker
+ * color: (Optional) Color of the marker
+ */
+export interface Marker {
+  lat: number;
+  long: number;
+  color?: MarkerColor;
+}
+
+/**
+ * StaticMapProps
+ * mapWidth: width of the map (maximum is 640px)
+ * mapHeight: height of the map  (maximum is 640px)
+ * mapScale: scale of the map (1 or 2), 2 will double the resolution
+ * markers: array of Marker with latitude and longitude
+ * markerSize: the size of the markers on the map ("tiny" | "small" | "mid")
+ * Refer to Google static map API for more information
+ */
+export interface StaticMapProps {
+  mapWidth: number;
+  mapHeight: number;
+  mapScale: 1 | 2;
+  markers: Array<Marker>;
+  markerSize: "tiny" | "small" | "mid";
+  onClick: (e: MouseEvent<HTMLElement>) => void;
+}
+
+// TODO: Remove this before merging into master
+const SAMPLE_LAT_LONG: Array<Marker> = [
+  { lat: 49.2606, long: -123.246, color: MarkerColor.Grey },
+  { lat: 49.22446, long: -123.11864, color: MarkerColor.Blue },
+  { lat: 49.18056, long: -123.18021, color: MarkerColor.Grey },
+  { lat: 49.28737, long: -123.12911 },
+];
+
+export class StaticMap extends Component<StaticMapProps> {
+  public static defaultProps: StaticMapProps = {
+    mapWidth: 640,
+    mapHeight: 224,
+    mapScale: 2,
+    onClick: () => {},
+    markerSize: "small",
+    // TODO: Update this to empty array before merging into master
+    markers: SAMPLE_LAT_LONG,
+  };
+
+  /**
+   * Generate the google map API URL based on the map props and location of markers
+   */
+  private getMapUrl(mapProps: StaticMapProps): string {
+    const baseUrl = new URL("https://maps.googleapis.com/maps/api/staticmap");
+
+    const urlParams = new URLSearchParams({
+      size: `${mapProps.mapWidth}x${mapProps.mapHeight}`,
+      scale: `${mapProps.mapScale}`,
+      key: `${MAP_KEY}`,
+    });
+
+    const markersParams = this.getMarkerParams(mapProps.markers);
+    markersParams.forEach((param) => {
+      urlParams.append("markers", param);
+    });
+
+    // Center the map at a location when there is no marker
+    if (this.props.markers.length === 0) {
+      urlParams.append("center", "vancouver");
+    }
+
+    baseUrl.search = `?${urlParams.toString()}`;
+    return baseUrl.toString();
+  }
+
+  /**
+   * To define markers with different style, we have to supply multiple Markers parameter in the URL
+   * Each parameter will be defined by a color followed by size and coordinates of markers
+   * This function forms the parameters and return them in a array
+   */
+  private getMarkerParams(markers: Array<Marker>): string[] {
+    let paramsMap: any = {};
+
+    const markerColors = Object.values(MarkerColor);
+    markerColors.forEach((color) => {
+      paramsMap[color] = "";
+    });
+
+    markers.forEach((marker) => {
+      if (marker.color) {
+        paramsMap[marker.color] = `${paramsMap[marker.color]}|${marker.lat},${
+          marker.long
+        }`;
+      } else {
+        paramsMap[MarkerColor.Grey] = `${paramsMap[MarkerColor.Grey]}|${
+          marker.lat
+        },${marker.long}`;
+      }
+    });
+
+    markerColors.forEach((color) => {
+      if (paramsMap[color] !== "") {
+        paramsMap[color] = `|size:${this.props.markerSize}${paramsMap[color]}`;
+        paramsMap[color] = `color:0x${color}${paramsMap[color]}`;
+      } else {
+        delete paramsMap[color];
+      }
+    });
+
+    return Object.values(paramsMap);
+  }
+
+  render() {
+    return (
+      <div className="static-map-wrapper">
+        <div className="static-map-image">
+          <Image src={this.getMapUrl(this.props)} />
+        </div>
+        <div
+          className="static-map-overlay"
+          onClick={(e) => this.props.onClick(e)}>
+          <Button icon="expand" text="Expand View" />
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/Map/StaticMap.tsx
+++ b/src/components/Map/StaticMap.tsx
@@ -1,7 +1,6 @@
 import React, { MouseEvent, Component, RefObject } from "react";
 import { Image } from "../Image/Image";
 import { Button } from "../Button/Button";
-import { MAP_KEY } from "./constant";
 import "./StaticMap.scss";
 
 /**
@@ -130,7 +129,7 @@ export class StaticMap extends Component<StaticMapProps, StaticMapState> {
     const urlParams = new URLSearchParams({
       size: `${Math.round(mapSize[0])}x${Math.round(mapSize[1])}`,
       scale: `${mapProps.mapScale}`,
-      key: `${MAP_KEY}`,
+      key: `${process.env.REACT_APP_MAP_API_KEY}`,
     });
 
     const markersParams = this.getMarkerParams(mapProps.markers);

--- a/src/components/Map/StaticMap.tsx
+++ b/src/components/Map/StaticMap.tsx
@@ -27,12 +27,14 @@ export interface Marker {
 
 /**
  * StaticMapProps
+ * height: height of the static map (in rem)
  * mapScale: scale of the map (1 or 2), 2 will double the resolution
  * markers: array of Marker with latitude and longitude
  * markerSize: the size of the markers on the map ("tiny" | "small" | "mid")
  * Refer to Google static map API for more information
  */
 export interface StaticMapProps {
+  height: number;
   mapScale: 1 | 2;
   markers: Array<Marker>;
   markerSize: "tiny" | "small" | "mid";
@@ -59,6 +61,7 @@ const SAMPLE_LAT_LONG: Array<Marker> = [
 
 export class StaticMap extends Component<StaticMapProps, StaticMapState> {
   public static defaultProps: StaticMapProps = {
+    height: 31.25,
     mapScale: 2,
     onClick: () => {},
     markerSize: "small",
@@ -183,7 +186,10 @@ export class StaticMap extends Component<StaticMapProps, StaticMapState> {
 
   render() {
     return (
-      <div className="static-map-wrapper" ref={this.mapRef}>
+      <div
+        className="static-map-wrapper"
+        ref={this.mapRef}
+        style={{ height: `${this.props.height}rem` }}>
         <div className="static-map-image">
           <Image
             src={this.getMapUrl(this.props)}

--- a/src/components/Map/constant.tsx
+++ b/src/components/Map/constant.tsx
@@ -1,1 +1,0 @@
-export const MAP_KEY = "AIzaSyCdiWIZIVkqOw7pmXBEMria1Qe4TxgKbo0";

--- a/src/components/Map/constant.tsx
+++ b/src/components/Map/constant.tsx
@@ -1,0 +1,1 @@
+export const MAP_KEY = "AIzaSyCdiWIZIVkqOw7pmXBEMria1Qe4TxgKbo0";

--- a/src/components/fontawesome.tsx
+++ b/src/components/fontawesome.tsx
@@ -21,7 +21,7 @@ import {
   faBed,
   faShoppingCart,
   faBinoculars,
-  faExpand,
+  faExternalLinkAlt,
 } from "@fortawesome/free-solid-svg-icons";
 import {
   faQuestionCircle,
@@ -56,5 +56,5 @@ library.add(
   faBed,
   faShoppingCart,
   faBinoculars,
-  faExpand
+  faExternalLinkAlt
 );

--- a/src/components/fontawesome.tsx
+++ b/src/components/fontawesome.tsx
@@ -21,6 +21,7 @@ import {
   faBed,
   faShoppingCart,
   faBinoculars,
+  faExpand,
 } from "@fortawesome/free-solid-svg-icons";
 import {
   faQuestionCircle,
@@ -54,5 +55,6 @@ library.add(
   faUtensils,
   faBed,
   faShoppingCart,
-  faBinoculars
+  faBinoculars,
+  faExpand
 );


### PR DESCRIPTION
### Static map component 
- This component display a static map with optional markers at specified location. 
- Longitude and latitude are used to specify the location of the markers. We can get these long and lat by using the Google geocoding API. 
- Map width, map height, map scale, marker color, and marker size are customizable using the props.  
- If no markers are provided, the map will focus on Vancouver.
- The map can be [styled](https://developers.google.com/maps/documentation/maps-static/styling) later on if required. Marker icon can be changed too.  

### map API
- Currently, three API are enabled: geocoding, map, and place. Let me know if [other API](https://developers.google.com/maps/documentation) are needed.  

![image](https://user-images.githubusercontent.com/36020702/85125938-5892e000-b1e1-11ea-84a9-549f815b32e0.png)



Closes #43  :metal: