### PR TITLE
Search bar bug fixes + minor ui change

### DIFF
--- a/packages/client/src/components/CoverPhoto/coverPhoto.scss
+++ b/packages/client/src/components/CoverPhoto/coverPhoto.scss
@@ -25,13 +25,8 @@
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
-    cursor: pointer;
     display: flex;
     justify-content: center;
-    &:hover {
-        opacity: 0.7;
-    }
-    transition: opacity 0.5s;
 }
 
 .coverPhotoImageEnlarged {

--- a/packages/client/src/components/SearchBar/SearchBar.tsx
+++ b/packages/client/src/components/SearchBar/SearchBar.tsx
@@ -138,9 +138,12 @@ export class SearchBar extends React.Component<{}, SearchBarState> {
                 <div className="results-container">
                     <ul className="results-list">
                         {results.map((result) => (
-                            <li className="results-entry" key={result.uuid}>
-                                <Link to={result.href}>{result.name}</Link>
-                            </li>
+                            <Link
+                                to={result.href}
+                                onClick={(e) => this.setState({ resultsOpen: false })}
+                                key={result.uuid}>
+                                <li className="results-entry">{result.name}</li>
+                            </Link>
                         ))}
                     </ul>
                 </div>

--- a/packages/client/src/components/SearchBar/searchBar.scss
+++ b/packages/client/src/components/SearchBar/searchBar.scss
@@ -142,6 +142,10 @@
         padding: 1em 0;
         background-color: $tc-white;
         z-index: 1000;
+        a {
+            color: $mid-gray;
+            text-decoration: none;
+        }
         .results-list {
             padding: 0;
             margin: 0;
@@ -153,10 +157,7 @@
             line-height: 2.5em;
             text-align: start;
             cursor: pointer;
-            a {
-                color: $mid-gray;
-                text-decoration: none;
-            }
+
             &:hover {
                 transition: background-color 0.3s ease;
                 background-color: rgba($indigo-dye, 0.04);

--- a/packages/client/src/pages/Trecipe/TrecipePage.tsx
+++ b/packages/client/src/pages/Trecipe/TrecipePage.tsx
@@ -75,6 +75,18 @@ class TrecipePage extends React.Component<TrecipeProps, TrecipeState> {
         this.props.getDestinationsByTrecipeId(trecipeId);
     }
 
+    componentDidUpdate(
+        prevProps: Readonly<TrecipeProps>,
+        prevState: Readonly<TrecipeState>,
+        snapshot?: any
+    ) {
+        const trecipeId = this.props.match.params.trecipeId;
+        if (prevProps.match.params.trecipeId !== trecipeId) {
+            this.props.fetchTrecipe(trecipeId);
+            this.props.getDestinationsByTrecipeId(trecipeId);
+        }
+    }
+
     private onDestDragEnd(result: DropResult, provided: ResponderProvided) {
         if (result.destination) {
             const dests: Array<Destination> = TrecipePage.reorder(

--- a/packages/server/server/api/search/search.controller.ts
+++ b/packages/server/server/api/search/search.controller.ts
@@ -75,9 +75,16 @@ class SearchController implements Controller {
     private searchTrecipe(keyword: string, offset: number, limit: number): Promise<Trecipe[]> {
         return trecipeModel
             .find({
-                $or: [
-                    { name: { $regex: '.*(?i)' + keyword + '.*' } },
-                    { description: { $regex: '.*' + keyword + '.*' } },
+                $and: [
+                    {
+                        $or: [
+                            { name: { $regex: '.*(?i)' + keyword + '.*' } },
+                            { description: { $regex: '.*' + keyword + '.*' } },
+                        ],
+                    },
+                    {
+                        isPrivate: false,
+                    },
                 ],
             })
             .skip(offset)


### PR DESCRIPTION
As per discussion, fixed bunch of bugs
1. Clicking on search entry does not close search bar
2. Routing does not reload trecipe
3. Make entire search result clickable
4. Make search result only display public Trecipes

Right now routing to other people's public Trecipe still does not work due to a bug we discussed. Will be fixed once @knox153 checks in his endpoint for fetching public Trecipes.